### PR TITLE
Fix clap_lex to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_derive = "1.0.147"
 base64 = "0.13.1"
 rand = "0.8.5"
 clap = { version = "4.0.26", features = ["derive"] }
+clap_lex = "0.3.0"
 proc-macro2 = "1.0.47"  # to resolve conflict when adding clap
 log = "0.4"
 log4rs = "1"


### PR DESCRIPTION
Fix clap_lex to 0.3.0 to avoid the following error:

```
error: package `clap_lex v0.3.1` cannot be built because it requires rustc 1.64.0 or newer, while the currently active rustc version is 1.61.0
```